### PR TITLE
README updates (various)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,230 @@
 # SynthTool (for client libraries)
-
 This tool helps to generate and layout cloud client libraries. 
 
 ## Installation
+This tool requires Python 3.6. Either install it from [python.org][python_downloads] or use
+[pyenv][] to get 3.6.
 
-This tool requires Python 3.6. Either install it from python.org or use
-pyenv to get 3.6.
+[python_downloads]: https://www.python.org/downloads/
+[pyenv]: https://github.com/pyenv/pyenv
 
-
+### Install latest
 ```
-# Install latest
-
 python3 -m pip install --user --upgrade git+https://github.com/googleapis/synthtool.git
+```
 
-# Install stable
+### Install stable
+```
 python3 -m pip install --user --upgrade gcp-synthtool
 ```
 
 ## Basic usage
-
-### Python
-
-To start the process of generation, we need to clone the destination repository.
-
+To start the process of generation, clone the destination repository.
 ```
 git clone git@github.com:googleapis/google-cloud-python.git
-cd google-cloud-python
-cd {cloud-package}
+cd google-cloud-python/
 ```
 
-If a `synth.py` script is not present at the root of the package, we will need
-to author a synth.py script. You can grab one from another package 
-(for instance tasks in python) or start from scratch.
+Navigate to the destination directory to generate the library.
+```
+cd google-cloud-tasks/
+```
 
-We run synthtool as follows:
+### Running `synthtool`
+If a `synth.py` script is not present, create a new one.
+
+You can create one from scratch or copy one from another library.
+ - e.g. the `synth.py` for the Cloud Tasks API for [Python][python_tasks_synth_py],
+[Java][java_tasks_synth_py], [Node.js][node_tasks_synth_py], [PHP][php_tasks_synth_py],
+or [Ruby][ruby_tasks_synth_py].
+
+Run `synthtool`:
+
 ```
 python3 -m synthtool
 ```
 
-Once you run synthtool without errors:
-- Investigate the changes it made just to be certain everything looks reasonable
-- run the unit tests (nox)
-- commit and push the changes to a branch and open a PR!
+After `synthtool` runs successfully:
+ - Investigate the changes it made
+ - Run the library tests
+ - Commit and push the changes to a branch and open a Pull Request
+ 
+Find examples below in different programming languages (Cloud Tasks API used as an example).
+
+### Python
+- Clone the destination repository:
+  ```
+  git clone git@github.com:googleapis/google-cloud-python.git
+  cd google-cloud-python/
+  ```
+- Navigate to the destination directory to generate the library:
+  ```
+  cd google-cloud-tasks/
+  ```
+- Run `synthtool` to generate using the existing [`synth.py`][python_tasks_synth_py]
+  file for the [Python Client for Cloud Tasks API][python_tasks_library]:
+  ```
+  python3 -m synthtool
+  ```
+- See the Python [Contributing Guide][python_contributing]
+  or instructions to install dependencies, run tests, and submit a contribution.
+
+[python_tasks_library]: https://github.com/googleapis/google-cloud-python/tree/master/tasks
+[python_tasks_synth_py]: https://github.com/googleapis/google-cloud-python/blob/master/tasks/synth.py
+[python_contributing]: https://github.com/googleapis/google-cloud-python/blob/master/CONTRIBUTING.rst
+
+### Java
+- Clone the destination repository:
+  ```
+  git clone git@github.com:googleapis/google-cloud-java.git
+  cd google-cloud-java/
+  ```
+- Navigate to the destination directory to generate the library:
+  ```
+  cd google-cloud-clients/google-cloud-tasks/
+  ```
+- Run `synthtool` to generate using the existing [`synth.py`][java_tasks_synth_py]
+  file for the [Google Cloud Java Client for Cloud Tasks][java_tasks_library]:
+  ```
+  python3 -m synthtool
+  ```
+- See the Java [Contributing Guide][java_contributing]
+  or instructions to install dependencies, run tests, and submit a contribution.
+
+[java_tasks_library]: https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-tasks
+[java_tasks_synth_py]: https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-tasks/synth.py
+[java_contributing]: https://github.com/googleapis/google-cloud-java/blob/master/CONTRIBUTING.md
 
 ### Node.js
-Node.js generation is similar to python. For an example `synth.py` you can look at https://github.com/googleapis/nodejs-speech/blob/master/synth.py.
+- Clone the destination repository:
+  ```
+  git clone git@github.com:googleapis/nodejs-tasks.git
+  cd nodejs-tasks/
+  ```
+- Run `synthtool` to generate using the existing [`synth.py`][node_tasks_synth_py]
+  file for the [Google Cloud Tasks Node.js Client][node_tasks_library]:
+  ```
+  python3 -m synthtool
+  ```
+- See the Node.js [Contributing Guide][node_tasks_contributing]
+  or instructions to install dependencies, run tests, and submit a contribution.
+
+[node_tasks_library]: https://github.com/googleapis/nodejs-task
+[node_tasks_synth_py]: https://github.com/googleapis/nodejs-tasks/blob/master/synth.py
+[node_tasks_contributing]: https://github.com/googleapis/nodejs-tasks/blob/master/CONTRIBUTING.md
+
+### PHP
+- Clone the destination repository:
+  ```
+  git clone git@github.com:googleapis/google-cloud-php.git
+  cd google-cloud-php/
+  ```
+- Navigate to the destination directory to generate the library:
+  ```
+  cd Tasks/
+  ```
+- Run `synthtool` to generate using the existing [`synth.py`][php_tasks_synth_py]
+  file for the [Google Cloud Tasks client for PHP][php_tasks_library]:
+  ```
+  python3 -m synthtool
+  ```
+- See the PHP [Contributing Guide][php_contributing]
+  or instructions to install dependencies, run tests, and submit a contribution.
+
+[php_tasks_library]: https://github.com/googleapis/google-cloud-php/tree/master/Tasks
+[php_tasks_synth_py]: https://github.com/googleapis/google-cloud-php/blob/master/Tasks/synth.py
+[php_contributing]: https://github.com/googleapis/google-cloud-php/blob/master/CONTRIBUTING.md
 
 ### Ruby
-- TODO. Should be similar to Python
+- Clone the destination repository:
+  ```
+  git clone git@github.com:googleapis/google-cloud-ruby.git
+  cd google-cloud-ruby/
+  ```
+- Navigate to the destination directory to generate the library:
+  ```
+  cd google-cloud-tasks/
+  ```
+- Run `synthtool` to generate using the existing [`synth.py`][ruby_tasks_synth_py]
+  file for the [Ruby Client for Cloud Tasks API][ruby_tasks_library]:
+  ```
+  python3 -m synthtool
+  ```
+- See the Ruby [Contributing Guide][ruby_contributing]
+  or instructions to install dependencies, run tests, and submit a contribution.
 
+[ruby_tasks_library]: https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-tasks
+[ruby_tasks_synth_py]: https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-tasks/synth.py
+[ruby_contributing]: https://github.com/googleapis/google-cloud-ruby/blob/master/.github/CONTRIBUTING.md
 
 ## Features
 ### Templating
-Synthtool supports template files using jinja. As an example let's look at node.js. The templates for node can be found at `/synthtool/gcp/templates/node_library/`. The following is taken from a node.js synth script.
+SynthTool supports template files using [Jinja](http://jinja.pocoo.org/).
 
-```
+Templates are found in subdirectories of [`synthtool/gcp/templates/`](synthtool/gcp/templates/)
+for each language,  
+ - e.g. the template directories for [Python][python_templates],
+[Node.js][node_templates], [PHP][php_tasks_synth_py], or [Ruby][ruby_templates].
+
+[python_templates]: synthtool/gcp/templates/python_library/
+[node_templates]: synthtool/gcp/templates/node_library/
+[php_templates]: synthtool/gcp/templates/php_library/
+[ruby_templates]:  synthtool/gcp/templates/ruby_library/
+
+You can generate and copy templates using `gcp.CommonTemplates` in your `synth.py`:
+```py
 common_templates = gcp.CommonTemplates()
 
-templates = common_templates.node_library(package_name="@google-cloud/speech")
+templates = common_templates.node_library()
 s.copy(templates)
 ```
 
-`package_name` is a keyword arg that is used by a jinja template. Jinja uses `{{ package_name }}` to customize the template for a specific package. You can add additionaly keyword args as necessary.
+You can provide variables to templates as keyword arguments to the library generation method:
+
+```py
+common_templates = gcp.CommonTemplates()
+
+templates = common_templates.node_library(version=5, show_version=True, previous_versions=[1,2,3,4])
+
+s.copy(templates)
+```
+
+Template files can access any values provided, e.g.
+ - `README.md.j2`
+    ```py
+    {% if show_version %}
+    The version is {{ version }}
+    
+    {% if previous versions is defined %}
+    Previous versions:
+      {% for ver in previous_versions %}
+      - {{ ver }}
+      {% endfor %}
+    {% endif %}
+    {% endif %}
+    ```
+
+You can learn more about Jinga templating in the
+[Template Designer Documentation](http://jinja.pocoo.org/docs/templates/).
 
 ### googleapis-private
-Synthtool supports generation from googleapis/googleapis-private. 
+SynthTool supports generation from googleapis/googleapis-private. 
 
-```
+```py
 gapic = gcp.GAPICGenerator()
+
 library = gapic.node_library('speech', 'v1', private=True)
 ```
 2FA is required to clone a private repo. 
 
-* **Using SSH:** Before running Synthtool, set the environment variable `AUTOSYNTH_USE_SSH` to `true`. The repo will be cloned using SSH.
-* **Using HTTPS:** Generate a [GitHub Personal Access Token](https://github.com/settings/tokens) with scope `repo`. Run synthtool. When GitHub prompts for your GitHub password, provide the access token instead.
+* **Using SSH:** Before running Synthtool, set the environment variable `AUTOSYNTH_USE_SSH` to `true`.
+
+The repo will be cloned using SSH.
+* **Using HTTPS:** Generate a [GitHub Personal Access Token](https://github.com/settings/tokens) with scope `repo`.
+Run `synthtool`.
+
+When GitHub prompts for your GitHub password, provide the access token instead.
+
 ```
 synthtool > Cloning googleapis-private.
 Username for 'https://github.com': busunkim96
@@ -81,20 +232,32 @@ Password for 'https://busunkim96@github.com':
 ```
 
 ### Artman Version
-Synthtool uses the latest version of the [Artman Docker image](https://hub.docker.com/r/googleapis/artman). You can change this by setting the environment variable `SYNTHTOOL_ARTMAN_VERSION` to the desired version tag.
+SynthTool uses the latest version of the [Artman Docker image](https://hub.docker.com/r/googleapis/artman).
+You can change this by setting the environment variable `SYNTHTOOL_ARTMAN_VERSION` to the desired version tag.
 
 ```
 export SYNTHTOOL_ARTMAN_VERSION=0.16.2
 ```
 
 ### Local Googleapis
-Synthtool supports generation from a local copy of googleapis. Specify the path to`googleapis` in the environment variable `SYNTHTOOL_GOOGLEAPIS`.
+SynthTool supports generation from a local copy of googleapis.
+Specify the path to`googleapis` in the environment variable `SYNTHTOOL_GOOGLEAPIS`.
 
 ```
 export SYNTHTOOL_GOOGLEAPIS=path/to/local/googleapis
 ```
 
+### Include .proto files
+SynthTool supports copying .proto API definition files from googleapis.
+
+```py
+gapic = gcp.GAPICGenerator()
+
+library = gapic.node_library('speech', 'v1', include_protos=True)
+```
 
 ## Helpful tips
 ### Where does the generated code go?
-Synthtool will run [Artman](https://hub.docker.com/r/googleapis/artman) which will create generated code that can be found at `~/.cache/synthtool/googleapis<-private>/artman_genfiles`. This is useful for figuring out what it is you need to copy for your specific library.
+SynthTool will run [Artman](https://hub.docker.com/r/googleapis/artman) which will create generated code that
+can be found at `~/.cache/synthtool/googleapis<-private>/artman_genfiles`. This is useful for figuring out
+what it is you need to copy for your specific library.


### PR DESCRIPTION
 - Add usage for Node.js, Java, PHP, and Ruby
 - Add useful links throughout README
 - Syntax highlight Python code demonstrating synth.py features
 - Document include_protos=True
 - Document CommonTemplates including Jinga basics and reference links
 - Little bits of consistency, e.g.
    - no newline after header
    - new newlines around code blocks
    - SynthTool when referring to tool/product
    - `synthtool` when explicitly referring to the CLI
    - Python is always used as the primary language. All languages which support SynthTool are included and always included in alphabetical order (with Python always starting first).